### PR TITLE
feat: add hook middleware support

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,3 +36,14 @@ await session.close()
 ```
 
 如果提供自定义工具/LLM/prompt/sink，可在 deps/options 中覆盖对应字段。默认配置会选择当前 provider 并写入用户目录的 sessions。
+
+## Hook 与中间件
+
+Core 支持在关键阶段注册 Hook，并可通过 middleware 链式扩展：
+
+- `onTurnStart(payload, next?)`：每轮开始时触发，`payload` 包含 `turn` 与用户输入。
+- `onAction(payload, next?)`：模型请求调用工具时触发，可用于审计参数或落盘。
+- `onObservation(payload, next?)`：工具返回后触发，`payload` 提供 `tool`、`observation`、`step` 等信息。
+- `onFinal(payload, next?)`：回合结束时触发，附带最终文本与状态码。
+
+Hook 既可以直接传入回调，也可以传入 `(next, payload) => { ...; await next() }` 形式的中间件数组，满足链路追踪、埋点等需求。所有 Hook 均为可选，未提供时不会影响主流程。

--- a/packages/core/src/runtime/hooks.test.ts
+++ b/packages/core/src/runtime/hooks.test.ts
@@ -1,0 +1,111 @@
+import { beforeAll, afterAll, describe, expect, test } from 'bun:test'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { $ } from 'bun'
+import { z } from 'zod'
+import { createAgentSession, createTokenCounter } from '@memo/core'
+import type { AgentSession } from '@memo/core'
+
+let tempHome: string
+let previousHome: string | undefined
+
+async function makeTempDir(prefix: string) {
+    const dir = join(tmpdir(), `${prefix}-${crypto.randomUUID()}`)
+    await $`mkdir -p ${dir}`
+    return dir
+}
+
+async function removeDir(dir: string) {
+    await $`rm -rf ${dir}`
+}
+
+describe('hook middleware chain', () => {
+    let session: AgentSession | undefined
+
+    beforeAll(async () => {
+        tempHome = await makeTempDir('memo-core-hooks')
+        previousHome = process.env.MEMO_HOME
+        process.env.MEMO_HOME = tempHome
+    })
+
+    afterAll(async () => {
+        if (session) {
+            await session.close()
+        }
+        if (previousHome === undefined) {
+            delete process.env.MEMO_HOME
+        } else {
+            process.env.MEMO_HOME = previousHome
+        }
+        await removeDir(tempHome)
+    })
+
+    test('runs optional hooks in order with middleware', async () => {
+        const calls: string[] = []
+        let llmStep = 0
+
+        session = await createAgentSession(
+            {
+                tools: {
+                    echo: {
+                        name: 'echo',
+                        description: 'echo text',
+                        inputSchema: z.object({ text: z.string() }),
+                        async execute(input) {
+                            return { content: [{ type: 'text', text: `echo:${input.text}` }] } as any
+                        },
+                    },
+                },
+                callLLM: async () => {
+                    llmStep += 1
+                    if (llmStep === 1) {
+                        return JSON.stringify({ tool: 'echo', input: { text: 'hello' } })
+                    }
+                    return JSON.stringify({ final: 'done' })
+                },
+                historySinks: [],
+                tokenCounter: createTokenCounter('cl100k_base'),
+                onTurnStart: [
+                    ({ turn, input }) => {
+                        calls.push(`start:${turn}:${input}`)
+                    },
+                    async (next, payload) => {
+                        calls.push('start-mw-before')
+                        await next()
+                        calls.push('start-mw-after')
+                    },
+                ],
+                onAction: ({ tool, input }) => {
+                    calls.push(`action:${tool}:${JSON.stringify(input)}`)
+                },
+                onObservation: [
+                    ({ observation }) => {
+                        calls.push(`ob:${observation}`)
+                    },
+                    async (next) => {
+                        calls.push('ob-mw-before')
+                        await next()
+                        calls.push('ob-mw-after')
+                    },
+                ],
+                onFinal: ({ final, status }) => {
+                    calls.push(`final:${final}:${status}`)
+                },
+            },
+            { mode: 'once' },
+        )
+
+        const result = await session.runTurn('hi')
+        expect(result.finalText).toBe('done')
+        expect(calls).toEqual([
+            'start:1:hi',
+            'start-mw-before',
+            'start-mw-after',
+            'action:echo:{"text":"hello"}',
+            'ob:echo:hello',
+            'ob-mw-before',
+            'ob-mw-after',
+            'final:done:ok',
+        ])
+    })
+})

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -116,7 +116,7 @@ async function runInteractive(parsed: ParsedArgs) {
             }
             process.stdout.write(text)
         },
-        onObservation: (tool: string, observation: string, step: number) => {
+        onObservation: ({ tool, observation, step }) => {
             console.log(`\n[第 ${step + 1} 步 工具=${tool}]\n${observation}\n`)
         },
     }


### PR DESCRIPTION
## Summary
- add middleware-capable hook handling for turn start, action, observation, and final stages
- document new optional hook payloads and middleware usage and adjust UI hook signatures
- add runtime test covering middleware ordering and optional hooks

## Testing
- bun test *(fails: dependency installation blocked by 403 errors from registry mirror)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69405b048fd4832eacdb33752498c64f)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add extensible hook middleware system to agent session lifecycle, enabling chainable callbacks for turn events, tool actions, observations, and final outputs with support for logging and tracing integrations.

Main changes:
- Implemented middleware chain execution with `runHookChain` function supporting both simple callbacks and next-based middleware
- Added four lifecycle hooks: `onTurnStart`, `onAction`, `onObservation`, `onFinal` with typed payload objects replacing callback parameters
- Replaced direct `onObservation` callback with hook middleware pattern throughout agent turn execution loop
- Created comprehensive test suite validating middleware execution order and payload propagation across hook chain

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
