### PR TITLE
fix: cli TUI english strings

### DIFF
--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -280,7 +280,7 @@ export function App({
     const handleHistorySelect = useCallback(
         async (entry: InputHistoryEntry) => {
             if (!entry.sessionFile) {
-                appendSystemMessage('历史记录', '该记录没有可加载的上下文文件。')
+                appendSystemMessage('History', 'This entry has no context file to load.')
                 return
             }
             try {
@@ -296,11 +296,11 @@ export function App({
                 currentTurnRef.current = null
                 // 重新拉起 session，避免旧上下文残留/计数错位
                 setSessionOptionsState((prev) => ({ ...prev, sessionId: randomUUID() }))
-                appendSystemMessage('历史记录已加载', parsed.summary || entry.input)
+                appendSystemMessage('History loaded', parsed.summary || entry.input)
             } catch (err) {
                 appendSystemMessage(
-                    '历史记录加载失败',
-                    `无法读取 ${entry.sessionFile}: ${(err as Error).message}`,
+                    'Failed to load history',
+                    `Unable to read ${entry.sessionFile}: ${(err as Error).message}`,
                 )
             }
         },
@@ -314,7 +314,10 @@ export function App({
                 const nextConfig = { ...loaded.config, current_provider: name }
                 await writeMemoConfig(loaded.configPath, nextConfig)
             } catch (err) {
-                appendSystemMessage('配置保存失败', `未能保存模型选择: ${(err as Error).message}`)
+                appendSystemMessage(
+                    'Failed to save config',
+                    `Failed to save model selection: ${(err as Error).message}`,
+                )
             }
         },
         [appendSystemMessage],
@@ -328,11 +331,17 @@ export function App({
     const handleModelSelect = useCallback(
         async (provider: ProviderConfig) => {
             if (provider.name === currentProvider && provider.model === currentModel) {
-                appendSystemMessage('模型切换', `已在使用 ${provider.name} (${provider.model})`)
+                appendSystemMessage(
+                    'Model switch',
+                    `Already using ${provider.name} (${provider.model})`,
+                )
                 return
             }
             if (busy) {
-                appendSystemMessage('模型切换', '当前正在运行，按 Esc Esc 取消后再切换模型。')
+                appendSystemMessage(
+                    'Model switch',
+                    'Currently running. Press Esc Esc to cancel before switching models.',
+                )
                 return
             }
             setTurns([])
@@ -350,7 +359,10 @@ export function App({
                 providerName: provider.name,
             }))
             await persistCurrentProvider(provider.name)
-            appendSystemMessage('模型切换', `已切换到 ${provider.name} (${provider.model})`)
+            appendSystemMessage(
+                'Model switch',
+                `Switched to ${provider.name} (${provider.model})`,
+            )
         },
         [appendSystemMessage, busy, currentModel, currentProvider, persistCurrentProvider],
     )
@@ -407,7 +419,7 @@ export function App({
                 setContextLimit(result.limit)
                 appendSystemMessage(
                     'Context length',
-                    `已设置上下文上限为 ${(result.limit / 1000).toFixed(0)}k tokens`,
+                    `Context limit set to ${(result.limit / 1000).toFixed(0)}k tokens`,
                 )
                 return
             }
@@ -554,7 +566,7 @@ Make the AGENTS.md concise but informative, following best practices for AI agen
                     setContextLimit(limit)
                     appendSystemMessage(
                         'Context length',
-                        `已设置上下文上限为 ${(limit / 1000).toFixed(0)}k tokens`,
+                        `Context limit set to ${(limit / 1000).toFixed(0)}k tokens`,
                     )
                 }}
                 history={inputHistory}

--- a/packages/cli/src/tui/components/layout/InputPrompt.tsx
+++ b/packages/cli/src/tui/components/layout/InputPrompt.tsx
@@ -345,7 +345,7 @@ export function InputPrompt({
                 onSetContextLimit?.(limit)
                 onSystemMessage?.(
                     'Context',
-                    `已设置上下文上限为 ${(limit / 1000).toFixed(0)}k tokens`,
+                    `Context limit set to ${(limit / 1000).toFixed(0)}k tokens`,
                 )
                 valueRef.current = ''
                 setValue('')

--- a/packages/cli/src/tui/slash/context.ts
+++ b/packages/cli/src/tui/slash/context.ts
@@ -2,7 +2,7 @@ import type { SlashCommand } from './types'
 
 export const contextCommand: SlashCommand = {
     name: 'context',
-    description: '设置上下文长度限制 (80k/120k/150k/200k)',
+    description: 'Set context length limit (80k/120k/150k/200k)',
     run: ({ closeSuggestions, setInputValue, showSystemMessage, data }) => {
         closeSuggestions()
         const options = '80k, 120k, 150k, 200k'

--- a/packages/cli/src/tui/slash/exit.ts
+++ b/packages/cli/src/tui/slash/exit.ts
@@ -2,7 +2,7 @@ import type { SlashCommand } from './types'
 
 export const exitCommand: SlashCommand = {
     name: 'exit',
-    description: '退出当前会话',
+    description: 'Exit the session',
     run: ({ closeSuggestions, exitApp }) => {
         closeSuggestions()
         exitApp()

--- a/packages/cli/src/tui/slash/help.ts
+++ b/packages/cli/src/tui/slash/help.ts
@@ -23,7 +23,7 @@ Shortcuts:
 
 export const helpCommand: SlashCommand = {
     name: 'help',
-    description: '显示帮助信息',
+    description: 'Show help',
     run: ({ closeSuggestions, setInputValue, showSystemMessage }) => {
         closeSuggestions()
         setInputValue('')

--- a/packages/cli/src/tui/slash/history.ts
+++ b/packages/cli/src/tui/slash/history.ts
@@ -2,7 +2,7 @@ import type { SlashCommand } from './types'
 
 export const resumeCommand: SlashCommand = {
     name: 'resume',
-    description: '恢复历史输入',
+    description: 'Resume history',
     run: ({ closeSuggestions, setInputValue, showSystemMessage }) => {
         closeSuggestions(false)
         setInputValue('resume ')

--- a/packages/cli/src/tui/slash/mcp.ts
+++ b/packages/cli/src/tui/slash/mcp.ts
@@ -32,7 +32,7 @@ function formatServerConfig(name: string, config: MCPServerConfig): string {
 
 export const mcpCommand: SlashCommand = {
     name: 'mcp',
-    description: '查看当前配置的 MCP servers',
+    description: 'Show configured MCP servers',
     run: ({ closeSuggestions, setInputValue, showSystemMessage, data }) => {
         closeSuggestions()
 

--- a/packages/cli/src/tui/slash/models.ts
+++ b/packages/cli/src/tui/slash/models.ts
@@ -2,7 +2,7 @@ import type { SlashCommand } from './types'
 
 export const modelsCommand: SlashCommand = {
     name: 'models',
-    description: '选择模型（展示配置里的 providers）',
+    description: 'Select a model (from configured providers)',
     run: ({ closeSuggestions, setInputValue, showSystemMessage, data }) => {
         closeSuggestions(false)
 

--- a/packages/cli/src/tui/slash/new.ts
+++ b/packages/cli/src/tui/slash/new.ts
@@ -2,7 +2,7 @@ import type { SlashCommand } from './types'
 
 export const newCommand: SlashCommand = {
     name: 'new',
-    description: '开启一个新对话',
+    description: 'Start a new session',
     run: ({ closeSuggestions, setInputValue, clearScreen, showSystemMessage, newSession }) => {
         closeSuggestions()
         setInputValue('')


### PR DESCRIPTION
### Motivation
- Convert Chinese UI copy in the CLI TUI to English for consistency and broader accessibility.

### Description
- Replaced Chinese system messages and status lines in `packages/cli/src/tui/App.tsx` with English equivalents (history, model switch, config save, context limit, shell messages, etc.).
- Updated context-limit feedback in `packages/cli/src/tui/components/layout/InputPrompt.tsx` to use English phrasing.
- Translated slash command descriptions to English in `packages/cli/src/tui/slash/*` (help, resume, models, new, mcp, exit, context).

### Testing
- No automated tests were run for this change (copy-only UI string updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981767d16888320b1e9a6553e9036e6)