### PR TITLE
chore: release v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@memo-code/memo",
-    "version": "0.5.15",
+    "version": "0.6.0",
     "private": false,
     "type": "module",
     "description": "A lightweight coding agent that runs in your terminal",


### PR DESCRIPTION
## Release goal
Publish memo-cli v0.6.0 from `dev` to `main`.

## Summary of notable changes
- feat: support batch edits in edit tool
- feat: max context limit config
- fix: enforce workspace-write sandbox for tools
- fix: validate native tool input before execution
- fix: require approval for save_memory writes
- fix: honor dangerous mode in session approval
- fix: cap tool outputs and enforce default prompt token limit
- refactor/docs/chore updates and release workflow skill additions

## Validation status
- Version bumped in root `package.json` to `0.6.0`
- Release commit pushed to `dev`: `484e6ea`
- Additional checks to be validated in CI after merge/tag