### PR TITLE
ci: fix web pages deploy install

### DIFF
--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+    - '.'
+
 ignoredBuiltDependencies:
     - sharp
     - unrs-resolver


### PR DESCRIPTION
## Problem
`Deploy Web to GitHub Pages` failed at `Install dependencies` with:

`ERROR packages field missing or empty`

## Root cause
`web/pnpm-workspace.yaml` existed but did not declare `packages`, so pnpm treated it as an invalid workspace during CI install.

## Fix
- Add `packages: ['.']` to `web/pnpm-workspace.yaml`
- Keep existing `ignoredBuiltDependencies` entries

## Validation
- `cd web && pnpm install --frozen-lockfile` passes
- `cd web && GITHUB_ACTIONS=true GITHUB_REPOSITORY=minorcell/memo-cli pnpm build` passes