### PR TITLE
fix(web): restore logo and favicon path on pages

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next'
 import './globals.css'
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
+const logoPath = `${basePath}/logo.svg`
+
 export const metadata: Metadata = {
     title: {
         default: 'Memo 官方站点',
@@ -8,9 +11,9 @@ export const metadata: Metadata = {
     },
     description: 'Memo: 运行在终端里的轻量级编码代理。本站提供产品介绍与完整文档站。',
     icons: {
-        icon: '/logo.svg',
-        shortcut: '/logo.svg',
-        apple: '/logo.svg',
+        icon: logoPath,
+        shortcut: logoPath,
+        apple: logoPath,
     },
 }
 

--- a/web/components/site-header.tsx
+++ b/web/components/site-header.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link'
 const navItems = [{ href: '/docs', label: 'Docs' }]
 const GITHUB_URL = 'https://github.com/minorcell/memo-cli'
 const NPM_URL = 'https://www.npmjs.com/package/@memo-code/memo'
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
+const logoPath = `${basePath}/logo.svg`
 
 export function SiteHeader() {
     return (
@@ -12,7 +14,7 @@ export function SiteHeader() {
             <div className="panel flex items-center justify-between rounded-2xl px-4 py-3 md:px-5">
                 <Link href="/" className="flex items-center gap-3">
                     <Image
-                        src="/logo.svg"
+                        src={logoPath}
                         width={36}
                         height={36}
                         alt="Memo Logo"

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -13,6 +13,9 @@ const nextConfig: NextConfig = {
     basePath: pageBasePath,
     assetPrefix: pageBasePath,
     trailingSlash: true,
+    env: {
+        NEXT_PUBLIC_BASE_PATH: pageBasePath,
+    },
     images: {
         unoptimized: true,
     },


### PR DESCRIPTION
## Problem
After enabling GitHub Pages deployment under a repository subpath, header logo and tab icon requests were resolved from root (`/logo.svg`) and could be missing.

## Fix
- Expose `NEXT_PUBLIC_BASE_PATH` from `web/next.config.ts`
- Use base-path-aware `logoPath` in:
  - `web/components/site-header.tsx` (header logo)
  - `web/app/layout.tsx` metadata icons (`icon`, `shortcut`, `apple`)

## Validation
- `cd web && pnpm build`
- `cd web && GITHUB_ACTIONS=true GITHUB_REPOSITORY=minorcell/memo-cli pnpm build`
- Exported HTML references `/memo-cli/logo.svg` for both header logo and favicon links