### PR TITLE
chore: add issue governance automation and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug Report
+description: Report a reproducible bug in memo-cli
+labels: ['bug', 'needs-triage', 'area:tui']
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for filing a bug. Please search existing issues first and include the minimal reproduction.
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Pre-check
+          options:
+              - label: I searched open and closed issues and did not find an existing report.
+                required: true
+              - label: I can reproduce this on the latest version from this repository.
+                required: true
+    - type: input
+      id: version
+      attributes:
+          label: Version
+          placeholder: e.g. 0.6.0 / commit SHA
+      validations:
+          required: true
+    - type: input
+      id: os
+      attributes:
+          label: Environment
+          placeholder: e.g. macOS 14.6, Node 20, pnpm 9
+      validations:
+          required: true
+    - type: textarea
+      id: reproduce
+      attributes:
+          label: Reproduction Steps
+          placeholder: |
+              1. ...
+              2. ...
+              3. ...
+      validations:
+          required: true
+    - type: textarea
+      id: expected
+      attributes:
+          label: Expected Behavior
+      validations:
+          required: true
+    - type: textarea
+      id: actual
+      attributes:
+          label: Actual Behavior
+      validations:
+          required: true
+    - type: textarea
+      id: logs
+      attributes:
+          label: Logs / Screenshots
+          description: Paste relevant terminal output, stack traces, or screenshots.
+          render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+    - name: Q&A / Usage questions
+      url: https://github.com/minorcell/memo-cli/discussions
+      about: Please use discussions for how-to and usage questions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ['enhancement', 'needs-triage']
+body:
+    - type: markdown
+      attributes:
+          value: |
+              Please describe user value and scope clearly. Search existing issues first to avoid duplicates.
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Pre-check
+          options:
+              - label: I searched existing issues and discussions and did not find the same request.
+                required: true
+    - type: textarea
+      id: problem
+      attributes:
+          label: Problem Statement
+          description: What user/problem is not solved well today?
+      validations:
+          required: true
+    - type: textarea
+      id: proposal
+      attributes:
+          label: Proposed Solution
+          description: Describe the preferred solution and key UX/API shape.
+      validations:
+          required: true
+    - type: textarea
+      id: alternatives
+      attributes:
+          label: Alternatives Considered
+          description: Optional; what alternatives did you evaluate?
+    - type: textarea
+      id: acceptance
+      attributes:
+          label: Acceptance Criteria
+          placeholder: |
+              - [ ] ...
+              - [ ] ...

--- a/.github/ISSUE_TEMPLATE/research_rfc.yml
+++ b/.github/ISSUE_TEMPLATE/research_rfc.yml
@@ -1,0 +1,38 @@
+name: Research / RFC
+description: Architecture or roadmap research proposal
+labels: ['enhancement', 'needs-triage', 'area:core']
+body:
+    - type: checkboxes
+      id: checks
+      attributes:
+          label: Pre-check
+          options:
+              - label: I searched existing roadmap/research issues.
+                required: true
+    - type: input
+      id: scope
+      attributes:
+          label: Scope
+          placeholder: e.g. CLI/TUI command architecture
+      validations:
+          required: true
+    - type: textarea
+      id: context
+      attributes:
+          label: Context
+      validations:
+          required: true
+    - type: textarea
+      id: analysis
+      attributes:
+          label: Comparison / Analysis
+          description: Include links and concrete evidence.
+      validations:
+          required: true
+    - type: textarea
+      id: plan
+      attributes:
+          label: Proposed Plan
+          description: Phases, milestones, risks, and rollback plan.
+      validations:
+          required: true

--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -1,0 +1,144 @@
+name: Issue Governance
+
+on:
+    issues:
+        types: [opened, edited, reopened]
+
+permissions:
+    contents: read
+    issues: write
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Auto-triage labels and duplicate hints
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const owner = context.repo.owner;
+                      const repo = context.repo.repo;
+                      const issue = context.payload.issue;
+                      const issueNumber = issue.number;
+                      const text = `${issue.title || ""}\n${issue.body || ""}`.toLowerCase();
+
+                      const labelDefs = {
+                        "needs-triage": { color: "f9d0c4", description: "Issue needs initial triage" },
+                        "duplicate-candidate": { color: "cfd3d7", description: "Potential duplicate, needs maintainer confirmation" },
+                        "area:tui": { color: "1d76db", description: "Terminal UI and interaction layer" },
+                        "area:tools": { color: "0e8a16", description: "Built-in tools and tool runtime" },
+                        "area:security": { color: "b60205", description: "Approval, sandbox, and security policy" },
+                        "area:core": { color: "5319e7", description: "Core runtime and session state" },
+                        "area:docs": { color: "0075ca", description: "Documentation and docs UX" },
+                      };
+
+                      async function ensureLabel(name) {
+                        try {
+                          await github.rest.issues.getLabel({ owner, repo, name });
+                        } catch (e) {
+                          if (e.status === 404) {
+                            const d = labelDefs[name];
+                            if (d) {
+                              await github.rest.issues.createLabel({ owner, repo, name, color: d.color, description: d.description });
+                            }
+                          } else {
+                            throw e;
+                          }
+                        }
+                      }
+
+                      const toAdd = new Set(["needs-triage"]);
+                      if (/\[bug\]|\bbug\b/.test(issue.title.toLowerCase())) toAdd.add("bug");
+                      if (/\[feature\]|\[feat\]|\bfeature\b|\bresearch\b|\brfc\b|\bproposal\b/.test(issue.title.toLowerCase())) toAdd.add("enhancement");
+                      if (/\bslash\b|\btui\b|\binput\b|\bprompt\b|\bresume\b/.test(text)) toAdd.add("area:tui");
+                      if (/\btool\b|\bmcp\b|\bskill\b|\bwebfetch\b|\bgrep\b|\bwrite\b|\bedit\b/.test(text)) toAdd.add("area:tools");
+                      if (/\bsandbox\b|\bapproval\b|\bdangerous\b|\bsecurity\b|\bexec policy\b/.test(text)) toAdd.add("area:security");
+                      if (/\bcore\b|\bsession\b|\bruntime\b|\barchitecture\b/.test(text)) toAdd.add("area:core");
+                      if (/\bdoc\b|\breadme\b|\bdocumentation\b/.test(text)) toAdd.add("area:docs");
+
+                      for (const name of toAdd) {
+                        await ensureLabel(name);
+                      }
+
+                      await github.rest.issues.addLabels({
+                        owner,
+                        repo,
+                        issue_number: issueNumber,
+                        labels: [...toAdd],
+                      });
+
+                      // Duplicate hint (non-destructive): token-overlap scoring against open issues.
+                      const stopwords = new Set([
+                        "the", "and", "for", "with", "that", "this", "from", "into", "memo", "cli", "tui",
+                        "feature", "bug", "review", "research", "issue", "openai", "codex", "支持", "新增", "问题"
+                      ]);
+
+                      function tokenize(s) {
+                        return new Set(
+                          s
+                            .toLowerCase()
+                            .replace(/[^\p{L}\p{N}\s]/gu, " ")
+                            .split(/\s+/)
+                            .map(t => t.trim())
+                            .filter(t => t.length >= 2 && !stopwords.has(t))
+                        );
+                      }
+
+                      function jaccard(a, b) {
+                        if (!a.size || !b.size) return 0;
+                        let inter = 0;
+                        for (const t of a) if (b.has(t)) inter++;
+                        const uni = new Set([...a, ...b]).size;
+                        return inter / uni;
+                      }
+
+                      const currentTokens = tokenize(`${issue.title} ${issue.body || ""}`);
+                      const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                        owner,
+                        repo,
+                        state: "open",
+                        per_page: 100,
+                      });
+
+                      const matches = openIssues
+                        .filter(i => !i.pull_request && i.number !== issueNumber)
+                        .map(i => {
+                          const tokens = tokenize(`${i.title} ${i.body || ""}`);
+                          return {
+                            number: i.number,
+                            title: i.title,
+                            url: i.html_url,
+                            score: jaccard(currentTokens, tokens),
+                          };
+                        })
+                        .filter(i => i.score >= 0.35)
+                        .sort((a, b) => b.score - a.score)
+                        .slice(0, 3);
+
+                      if (matches.length > 0) {
+                        await ensureLabel("duplicate-candidate");
+                        await github.rest.issues.addLabels({
+                          owner,
+                          repo,
+                          issue_number: issueNumber,
+                          labels: ["duplicate-candidate"],
+                        });
+
+                        const marker = "<!-- issue-governance:duplicate-check -->";
+                        const comments = await github.paginate(github.rest.issues.listComments, {
+                          owner,
+                          repo,
+                          issue_number: issueNumber,
+                          per_page: 100,
+                        });
+                        const alreadyCommented = comments.some(c => (c.body || "").includes(marker));
+                        if (!alreadyCommented) {
+                          const lines = matches.map(m => `- #${m.number} (${m.score.toFixed(2)}): ${m.title}\n  ${m.url}`);
+                          await github.rest.issues.createComment({
+                            owner,
+                            repo,
+                            issue_number: issueNumber,
+                            body: `${marker}\nPotential duplicates found:\n${lines.join("\n")}\n\nMaintainer: if this is duplicate, close with reason \`duplicate\` and link the canonical issue.`,
+                          });
+                        }
+                      }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,13 @@ Thanks for your interest in **Memo Code CLI**. Please read these guidelines befo
 - Recommended branch names: `feature/<topic>`, `fix/<topic>`, `docs/<topic>`.
 - In PRs, state change scope, risk points, and validation methods; keep commits clean and focused.
 
+## Issue Governance
+
+- New issues are triaged automatically with `needs-triage` and area/type labels.
+- Potential duplicates are flagged as `duplicate-candidate`; maintainers should confirm manually.
+- Confirmed duplicates should be closed with state reason `duplicate` and linked to the canonical issue.
+- Keep one canonical tracking issue per topic; use checklists/sub-issues there instead of parallel duplicates.
+
 ## Tips
 
 - Prioritize Core/Tools contracts and reusability; keep UI as a thin wrapper (see `docs/dev-direction.md`).

--- a/docs/issue-governance.md
+++ b/docs/issue-governance.md
@@ -1,0 +1,36 @@
+# Issue Governance
+
+This repository follows a lightweight issue governance workflow for open-source maintenance.
+
+## Goals
+
+- Keep one canonical issue per topic.
+- Reduce duplicate reports and fragmented discussions.
+- Ensure every open issue has clear type, area, and priority context.
+
+## Labels
+
+- Type: `bug`, `enhancement`, `documentation`, `question`
+- Area: `area:tui`, `area:tools`, `area:core`, `area:security`, `area:docs`
+- Status: `needs-triage`, `duplicate-candidate`, `status:blocked`
+- Priority: `priority:p0`, `priority:p1`
+
+## Triage Flow
+
+1. New issue gets auto-labeled by `.github/workflows/issue-governance.yml`.
+2. Maintainer verifies labels and sets priority.
+3. If duplicate is confirmed:
+    - Keep one canonical issue open.
+    - Close duplicates with reason `duplicate` and link canonical issue.
+4. For broad roadmap topics, use one tracking issue with checklist/sub-issues.
+
+## Duplicate Detection
+
+The automation posts non-blocking duplicate hints based on title/body token overlap.
+Maintainer confirmation is required before closing an issue as duplicate.
+
+## Contributor Expectations
+
+- Use issue forms instead of blank issues.
+- Search existing issues before opening a new one.
+- Include reproducible steps for bugs and acceptance criteria for features.


### PR DESCRIPTION
## Summary\n- add structured issue forms for bug/feature/research submissions\n- add issue governance workflow for auto-triage labels and duplicate hints\n- document issue governance policy in docs and contributing guide\n\n## Validation\n- prettier check passed for all changed files\n- full CI currently fails due unrelated formatting issue in web/next-env.d.ts\n\n## Notes\n- workflow is non-destructive for duplicates (labels/comments only); maintainer confirms before closing