### PR TITLE
chore: release v0.6.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@memo-code/memo",
-    "version": "0.6.32",
+    "version": "0.6.55",
     "private": false,
     "type": "module",
     "description": "A lightweight coding agent that runs in your terminal",


### PR DESCRIPTION
## Release Goal
Publish memo-cli `v0.6.55` from `dev` to `main`, then tag and release.

## Notable Changes Since v0.6.32
- Hardened `apply_patch` parser/matcher:
  - clearer format examples and parser errors
  - ambiguity detection for repeated context
  - `@@` header parsing and anchored matching with safe fallback
- Fixed tool-approval rejection protocol handling:
  - ensure every assistant `tool_call_id` is followed by matching `tool` messages even on deny/disabled/fail-fast
- Added session title generation from first prompt and persisted history display
- Added DeepSeek `reasoning_content` passthrough for follow-up tool-call compatibility
- Added startup MCP activation selection with persisted defaults
- Added startup `AGENTS.md` append to system prompt
- Added dangerous shell command blocking and related tool/runtime hardening

## Validation Status
- Local: `pnpm run ci` passed on latest dev before this release bump
- Release commit: version bump only (`package.json` 0.6.32 -> 0.6.55)
- CI: pending on this PR
