### PR TITLE
Hide mcp line when no MCP servers configured

### DIFF
--- a/packages/tui/src/features/timeline/ChatWidget.tsx
+++ b/packages/tui/src/features/timeline/ChatWidget.tsx
@@ -102,9 +102,11 @@ export const ChatWidget = memo(function ChatWidget({
                                     {item.data.version}
                                 </Text>
                                 <Text color="gray">cwd: {item.data.cwd}</Text>
-                                <Text color="gray">
-                                    mcp: {item.data.mcpNames.join(', ') || 'none'}
-                                </Text>
+                                {item.data.mcpNames.length > 0 ? (
+                                    <Text color="gray">
+                                        mcp: {item.data.mcpNames.join(', ')}
+                                    </Text>
+                                ) : null}
                             </Box>
                         )
                     }


### PR DESCRIPTION
## Summary
- When no MCP servers are active, hide the `mcp: none` line from the startup header

## Test plan
- [ ] Start memo with no MCP servers configured → no mcp line in header
- [ ] Start memo with MCP servers configured → mcp line shows server names

🤖 Generated with Memo Code